### PR TITLE
Update test dependencies in GitHub workflows

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -134,7 +134,7 @@ jobs:
           python -m pytest tests/unittests
 
   integration-tests-3-8:
-    needs: test-and-lint-3-8
+    needs: test-3-8
     name: Run integration tests for 3.8
     runs-on: ubuntu-latest
     steps:
@@ -155,7 +155,7 @@ jobs:
         run: >-
           python -m pytest tests/integrationtests/test_commands
   integration-tests-3-9:
-    needs: test-and-lint-3-9
+    needs: test-3-9
     name: Run integration tests for 3.9
     runs-on: ubuntu-latest
     steps:
@@ -176,7 +176,7 @@ jobs:
         run: >-
           python -m pytest tests/integrationtests/test_commands
   integration-tests-3-10:
-    needs: test-and-lint-3-10
+    needs: test-3-10
     name: Run integration tests for 3.10
     runs-on: ubuntu-latest
     steps:
@@ -197,7 +197,7 @@ jobs:
         run: >-
           python -m pytest tests/integrationtests/test_commands
   integration-tests-3-11:
-    needs: test-and-lint-3-11
+    needs: test-3-11
     name: Run integration tests for 3.11
     runs-on: ubuntu-latest
     steps:
@@ -218,7 +218,7 @@ jobs:
         run: >-
           python -m pytest tests/integrationtests/test_commands
   integration-tests-3-12:
-    needs: test-and-lint-3-12
+    needs: test-3-12
     name: Run integration tests for 3.12
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-and-lint-master.yml
+++ b/.github/workflows/test-and-lint-master.yml
@@ -133,7 +133,7 @@ jobs:
           python -m pytest tests/unittests
 
   integration-tests-3-8:
-    needs: test-and-lint-3-8
+    needs: test-3-8
     name: Run integration tests for 3.8
     runs-on: ubuntu-latest
     steps:
@@ -154,7 +154,7 @@ jobs:
         run: >-
           python -m pytest tests/integrationtests/test_commands
   integration-tests-3-9:
-    needs: test-and-lint-3-9
+    needs: test-3-9
     name: Run integration tests for 3.9
     runs-on: ubuntu-latest
     steps:
@@ -175,7 +175,7 @@ jobs:
         run: >-
           python -m pytest tests/integrationtests/test_commands
   integration-tests-3-10:
-    needs: test-and-lint-3-10
+    needs: test-3-10
     name: Run integration tests for 3.10
     runs-on: ubuntu-latest
     steps:
@@ -196,7 +196,7 @@ jobs:
         run: >-
           python -m pytest tests/integrationtests/test_commands
   integration-tests-3-11:
-    needs: test-and-lint-3-11
+    needs: test-3-11
     name: Run integration tests for 3.11
     runs-on: ubuntu-latest
     steps:
@@ -217,7 +217,7 @@ jobs:
         run: >-
           python -m pytest tests/integrationtests/test_commands
   integration-tests-3-12:
-    needs: test-and-lint-3-12
+    needs: test-3-12
     name: Run integration tests for 3.12
     runs-on: ubuntu-latest
     steps:
@@ -237,4 +237,3 @@ jobs:
       - name: Run integration tests
         run: >-
           python -m pytest tests/integrationtests/test_commands
-


### PR DESCRIPTION
The commit modifies all integration tests in GitHub actions workflow files to depend on 'test-x-x' jobs instead of 'test-and-lint-x-x'. This simplifies the job dependencies in the workflows, ensuring that integration tests only wait on the corresponding 'test' jobs and not the 'lint' jobs.