### PR TITLE
Add dependency on build-n-publish job to publish-toreqs

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -274,6 +274,8 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
   build-n-publish-toreqs:
+    needs:
+      - build-n-publish
     name: Build and publish Python 🐍 distributions 📦 to PyPI (toreqs)
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The publish-toreqs job now depends on the successful completion of the build-n-publish job. This ensures that Python distributions are built and published in the correct order, preventing potential errors.